### PR TITLE
Fix build error caused by last PR

### DIFF
--- a/src/types/dir.rs
+++ b/src/types/dir.rs
@@ -98,7 +98,7 @@ macro_rules! define_calculate_path {
                     .join(self.path.as_str()),
                 };
 
-                if let Some(stripped_path) = path.strip_prefix("~") {
+                if let Ok(stripped_path) = path.strip_prefix("~") {
                     let home = config_home().unwrap_or("/".to_string());
                     std::path::Path::new(&home).join(stripped_path)
                 } else {


### PR DESCRIPTION
`strip_prefix`returns [Err](https://doc.rust-lang.org/stable/std/result/enum.Result.html#variant.Err) if base is not a prefix of self (i.e., [starts_with](https://doc.rust-lang.org/stable/std/path/struct.Path.html#method.starts_with) returns false), .