### PR TITLE
Handle the `prefix` attribute specially for the `<include>` directive

### DIFF
--- a/src/types/dir.rs
+++ b/src/types/dir.rs
@@ -42,6 +42,13 @@ pub enum DirPrefix {
     Relative,
 }
 
+pub enum PrefixBehavior {
+    Config,
+    Cwd,
+    Xdg,
+    Relative,
+}
+
 parse_enum! {
     DirPrefix,
     (Default, "default"),
@@ -72,6 +79,20 @@ fn config_home() -> Result<String, std::env::VarError> {
     home
 }
 
+/// Given a relative path to a config file, this function returns
+/// the complete file name to load.
+///
+/// This is a simplified version of `FcConfigGetFilename` from the Fontconfig
+/// library.
+fn config_get_file_name(p: &std::path::PathBuf) -> std::path::PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        // TODO: get config file path properly for Windows
+        return p.clone();
+    }
+    std::path::Path::new("/etc/fonts").join(p)
+}
+
 fn expand_tilde(path: &String) -> std::path::PathBuf {
     let parsed_path = std::path::Path::new(path);
     if let Ok(stripped_path) = parsed_path.strip_prefix("~") {
@@ -83,12 +104,22 @@ fn expand_tilde(path: &String) -> std::path::PathBuf {
 }
 
 macro_rules! define_calculate_path {
-    ($ty:ident, $xdg_env:expr, $xdg_fallback:expr) => {
+    ($ty:ident, $xdg_env:expr, $xdg_fallback:expr, $default_prefix_behavior:expr) => {
         impl $ty {
             /// Environment variable name which used `xdg` prefix
             pub const XDG_ENV: &'static str = $xdg_env;
             /// Fallback path when `XDG_ENV` is not exists
             pub const XDG_FALLBACK_PATH: &'static str = $xdg_fallback;
+            const DEFAULT_PREFIX_BEHAVIOR: PrefixBehavior = $default_prefix_behavior;
+
+            fn get_prefix_behavior(prefix: DirPrefix) -> PrefixBehavior {
+                match prefix {
+                    DirPrefix::Default => Self::DEFAULT_PREFIX_BEHAVIOR,
+                    DirPrefix::Cwd => PrefixBehavior::Cwd,
+                    DirPrefix::Xdg => PrefixBehavior::Xdg,
+                    DirPrefix::Relative => PrefixBehavior::Relative
+                }
+            }
 
             /// Calculate actual path
             pub fn calculate_path<P: AsRef<std::path::Path> + ?Sized>(
@@ -97,26 +128,33 @@ macro_rules! define_calculate_path {
             ) -> std::path::PathBuf {
                 let expanded_path = expand_tilde(&self.path);
 
-                let path = match self.prefix {
-                    DirPrefix::Default => expanded_path.into(),
-                    DirPrefix::Cwd => std::path::Path::new(".").join(expanded_path),
-                    DirPrefix::Relative => match config_file_path.as_ref().parent() {
+                if expanded_path.is_absolute() {
+                    return expanded_path;
+                }
+
+                let prefix = Self::get_prefix_behavior(self.prefix);
+
+                match prefix {
+                    PrefixBehavior::Config => config_get_file_name(&expanded_path),
+                    PrefixBehavior::Cwd => std::path::Path::new(".").join(expanded_path),
+                    PrefixBehavior::Relative => match config_file_path.as_ref().parent() {
                         Some(parent) => parent.join(expanded_path),
                         None => std::path::Path::new(".").join(expanded_path),
                     },
-                    DirPrefix::Xdg => std::path::PathBuf::from(
-                        std::env::var($xdg_env).unwrap_or_else(|_| $xdg_fallback.into()),
-                    )
-                    .join(expanded_path),
-                };
-
-                path
+                    PrefixBehavior::Xdg => {
+                        let xdg_path = std::env::var($xdg_env)
+                            .unwrap_or_else(|_|
+                                $xdg_fallback.into()
+                            );
+                        expand_tilde(&xdg_path).join(expanded_path)
+                    }
+                }
             }
         }
     };
 }
 
-define_calculate_path!(Dir, "XDG_DATA_HOME", "~/.local/share");
-define_calculate_path!(CacheDir, "XDG_CACHE_HOME", "~/.cache");
-define_calculate_path!(Include, "XDG_CONFIG_HOME", "~/.config");
-define_calculate_path!(RemapDir, "XDG_CONFIG_HOME", "~/.config");
+define_calculate_path!(Dir, "XDG_DATA_HOME", "~/.local/share", PrefixBehavior::Cwd);
+define_calculate_path!(CacheDir, "XDG_CACHE_HOME", "~/.cache", PrefixBehavior::Cwd);
+define_calculate_path!(Include, "XDG_CONFIG_HOME", "~/.config", PrefixBehavior::Config);
+define_calculate_path!(RemapDir, "XDG_CONFIG_HOME", "~/.config", PrefixBehavior::Cwd);


### PR DESCRIPTION
## Motivation

Currently, for all of the four directives that has the `prefix` attribute (`include`, `dir`, `remap-dir`, `cachedir`), when `prefix` is omitted or is `default`, `calculate_path` will just return the (possibly tilde-expanded) path as is, which is more or less the same as using `cwd`.

However, fontconfig actually handles the `<include>` directive in a special way: if the path supplied is relative, then the "config path" instead of the CWD is prepended to it; this path is determined when fontconfig is built, and on Linux this is usually `/etc/fonts`. This PR implements this behavior. Note the new behavior is by far not a 1:1 clone of the fontconfig library, but is closer.

The change is important because the "builtin" config files follows this convention. For example, `/etc/fonts/fonts.conf` usually `include`s `conf.d`, which gets resolved as `/etc/fonts/conf.d`; and there's usually `/etc/fonts/conf.d/50-user.conf` which `include`s `fontconfig/conf.d` and `fontconfig/fonts.conf` with `prefix="xdg"`. That's the reason fontconfig finds and loads config files in `~/.config/fontconfig`. So after this change, on a usual Linux setup (Arch, NixOS, etc.), loading only `/etc/fonts/fonts.conf` should be sufficient to recursively import everything in `/etc/fonts/conf.d`, `~/.config/fontconfig/conf.d/*`, etc.

## Changes

After this PR, `calculate_path` works like this:
- First, do tilde expansion on the path.
- If the resulting path is absolute, then don't add any prefix and return that path.
- Otherwise, prepend the prefix as usual.
  - For `<include>` the default prefix to prepend on Linux is `/etc/fonts`. On Windows, fontconfig uses `GetModuleFileName` to get the path. From its docs I guess that's the path to the executable, but I cannot test so I just don't prepend any prefix. (Still, **I didn't run**, I just tried to make sure it can build.)
  - For the other directives the default prefix to prepend is the `./`. (The original "default" behavior here is to return the path as is, and they are equivalent for relative paths AFAIC. For absolute paths the new behavior is to return early, which AFAIC is more correct.)

P.S. The issue has already been reported to some consumers of this crate, e.g. https://github.com/RazrFalcon/fontdb/issues/59. I think those went to the wrong place :-)