### PR TITLE
fix: Merge configurations in lexicographic order

### DIFF
--- a/test-conf/conf.d/00-5_reset-dirs.conf
+++ b/test-conf/conf.d/00-5_reset-dirs.conf
@@ -1,0 +1,11 @@
+<?xml version='1.0'?>
+<!DOCTYPE fontconfig SYSTEM 'urn:fontconfig:fonts.dtd'>
+<fontconfig>
+  <!-- This should get reset. -->
+  <dir>/before/reset</dir>
+
+  <reset-dirs />
+
+  <!-- This should survive. -->
+  <dir>/after/reset</dir>
+</fontconfig>

--- a/test-conf/conf.d/00-5_reset-dirs.conf.json
+++ b/test-conf/conf.d/00-5_reset-dirs.conf.json
@@ -1,0 +1,17 @@
+[
+  {
+    "Dir": {
+      "prefix": "Default",
+      "salt": "",
+      "path": "/before/reset"
+    }
+  },
+  "ResetDirs",
+  {
+    "Dir": {
+      "prefix": "Default",
+      "salt": "",
+      "path": "/after/reset"
+    }
+  }
+]

--- a/test-conf/conf.d/00-6_reset-dirs-lex-order.conf
+++ b/test-conf/conf.d/00-6_reset-dirs-lex-order.conf
@@ -1,0 +1,8 @@
+<?xml version='1.0'?>
+<!DOCTYPE fontconfig SYSTEM 'urn:fontconfig:fonts.dtd'>
+<fontconfig>
+
+  <!-- This should not get reset by `00-5_reset-dirs.conf` as `00-6` runs after. -->
+  <dir>/after/after/reset</dir>
+
+</fontconfig>

--- a/test-conf/conf.d/00-6_reset-dirs-lex-order.conf.json
+++ b/test-conf/conf.d/00-6_reset-dirs-lex-order.conf.json
@@ -1,0 +1,9 @@
+[
+  {
+    "Dir": {
+      "prefix": "Default",
+      "salt": "",
+      "path": "/after/after/reset"
+    }
+  }
+]

--- a/test-conf/conf.d/10-scale-bitmap-fonts.conf.json
+++ b/test-conf/conf.d/10-scale-bitmap-fonts.conf.json
@@ -174,7 +174,7 @@
           "value": {
             "PixelSizeFixupFactor": {
               "Simple": {
-                "Double": 1
+                "Double": 1.0
               }
             }
           }
@@ -205,7 +205,7 @@
           "value": {
             "PixelSizeFixupFactor": {
               "Simple": {
-                "Double": 1
+                "Double": 1.0
               }
             }
           }
@@ -240,12 +240,12 @@
                       },
                       {
                         "Simple": {
-                          "Double": 0
+                          "Double": 0.0
                         }
                       },
                       {
                         "Simple": {
-                          "Double": 0
+                          "Double": 0.0
                         }
                       },
                       {

--- a/test-conf/conf.d/65-fonts-persian.conf.json
+++ b/test-conf/conf.d/65-fonts-persian.conf.json
@@ -542,7 +542,7 @@
                     "Matrix": [
                       {
                         "Simple": {
-                          "Double": 1
+                          "Double": 1.0
                         }
                       },
                       {
@@ -552,12 +552,12 @@
                       },
                       {
                         "Simple": {
-                          "Double": 0
+                          "Double": 0.0
                         }
                       },
                       {
                         "Simple": {
-                          "Double": 1
+                          "Double": 1.0
                         }
                       }
                     ]
@@ -731,7 +731,7 @@
           "value": {
             "Size": {
               "Simple": {
-                "Double": 24
+                "Double": 24.0
               }
             }
           }
@@ -787,7 +787,7 @@
           "value": {
             "Size": {
               "Simple": {
-                "Double": 24
+                "Double": 24.0
               }
             }
           }
@@ -843,7 +843,7 @@
           "value": {
             "Size": {
               "Simple": {
-                "Double": 24
+                "Double": 24.0
               }
             }
           }

--- a/test-conf/conf.d/90-synthetic.conf.json
+++ b/test-conf/conf.d/90-synthetic.conf.json
@@ -49,7 +49,7 @@
                     "Matrix": [
                       {
                         "Simple": {
-                          "Double": 1
+                          "Double": 1.0
                         }
                       },
                       {
@@ -59,12 +59,12 @@
                       },
                       {
                         "Simple": {
-                          "Double": 0
+                          "Double": 0.0
                         }
                       },
                       {
                         "Simple": {
-                          "Double": 1
+                          "Double": 1.0
                         }
                       }
                     ]

--- a/tests/merge.rs
+++ b/tests/merge.rs
@@ -5,6 +5,22 @@ fn merge_full() {
     let mut c = FontConfig::default();
     c.merge_config("./test-conf/fonts.conf").unwrap();
 
+    // 00-5_reset-dirs.conf
+    assert!(!c.dirs.contains(&DirData {
+        path: "/before/reset".into(),
+        salt: "".into(),
+    }));
+    assert!(c.dirs.contains(&DirData {
+        path: "/after/reset".into(),
+        salt: "".into(),
+    }));
+
+    // 00-6_reset-dirs-lex-order.conf
+    assert!(c.dirs.contains(&DirData {
+        path: "/after/after/reset".into(),
+        salt: "".into(),
+    }));
+
     // 00-nixos-cache.conf
     assert!(c.dirs.contains(&DirData {
         path: "/nix/store/i1yhgnfvaihqzs079lcx4zjnrdzcvaak-noto-fonts-2020-01-23".into(),

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -14,8 +14,12 @@ fn test_single_conf(path: PathBuf) -> Result<()> {
 
     let parts = parse_config_parts(std::fs::read_to_string(path)?.as_str())?;
 
-    let expected = std::fs::read_to_string(json_path)?;
-    let actual = serde_json::to_string(&parts).unwrap();
+    let expected_str = std::fs::read_to_string(json_path)?;
+    let expected: serde_json::Value = serde_json::from_str(&expected_str).unwrap();
+
+    let actual_str = serde_json::to_string(&parts).unwrap();
+    let actual: serde_json::Value = serde_json::from_str(&actual_str).unwrap();
+
     k9::assert_equal!(expected, actual);
 
     Ok(())


### PR DESCRIPTION
A `for..in` loop on a `BinaryHeap` is not sorted,
see https://doc.rust-lang.org/std/collections/struct.BinaryHeap.html#method.iter
so the old code, whilst presumably _intended_ to be sorted, was actually
iterating with a random order.

Collecting as a `Vec` then sorting is simpler and more efficient since
`read_dir` depends on FS and can be in ascending order which degrades
each insertion from `O(1)` to `O(log(n))`, amortised, for `BinaryHeap`,
see https://doc.rust-lang.org/alloc/collections/binary_heap/struct.BinaryHeap.html#time-complexity-3

That random order was causing downstream bugs:

- https://github.com/zed-industries/zed/issues/18982
- https://github.com/zed-industries/zed/issues/22676
- https://github.com/flathub/dev.lapce.lapce/issues/50
- https://github.com/RazrFalcon/fontdb/issues/78

as, e.g. inside a flatpak, `/etc/fonts/conf.d/05-flatpak-fontpath.conf`
features a `<reset-dirs />` that would then hide the flatpak-specific
`<dir>`s like `/run/host/fonts` in `/etc/fonts/conf.d/50-flatppk.conf`
if the `05-` file gets merged after the `50-` file.